### PR TITLE
ENH: adding basic (untested) configuration for pandas testing on sparc boxes

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -529,6 +529,13 @@ pymvpa_bot = GithubBot('PyMVPA', 'PyMVPA',
     pip_depends = ('nose',),
     build_timeout = 3600, # allow for its longer testing especially for sparcs.
 )
+# statsmodels bot, primarily for sparc testing
+sklearn_bot = GithubBot('scikit-learn', 'scikit-learn',
+    test_cmd = nptest_command('sklearn', doctests=True),
+    doc_build_cmd = "make -C doc html",
+    built_doc_src = "doc/build",
+    easy_depends = ('nose',),
+)
 ####### CHANGESOURCES
 
 # the 'change_source' setting tells the buildmaster how it should find out
@@ -544,6 +551,7 @@ c['change_source'] = [bot.poller() for bot in (nibabel_bot,
                                                regreg_bot,
                                                statsmodels_bot,
                                                pymvpa_bot,
+                                               sklearn_bot,
                                                )]
 
 # pandas is too expensive to test and overwhelmes the sparc box, so
@@ -654,6 +662,13 @@ c['schedulers'] = [
                         'pymvpa-py2.6-osx-10.5-ppc',
                         'pymvpa-py2.6-osx-10.5-intel',
                         'pymvpa-py2.6-xp',
+                        ]),
+    sklearn_bot.scheduler([
+                        'sklearn-py2.x-sid-sparc',
+                        # not yet
+                        #'sklearn-py3.x-sid-sparc',
+                        'sklearn-py2.6-wheezy-sparc',
+                        #'sklearn-py3.x-wheezy-sparc',
                         ]),
     nipy_bot.nightly_scheduler(['nipy-doc-builder'], 'doc', 2, 01, True),
     nibabel_bot.nightly_scheduler(['nibabel-doc-builder'], 'doc', 2, 20, True),
@@ -1106,6 +1121,12 @@ c['builders'] += pymvpa_bot.build_builders(
      ('pymvpa-py2.6-osx-10.5-intel', osx_leopard_intel_slaves),
      ('pymvpa-py2.6-xp', xp_32_slaves),
     ))
+# Sklearn
+c['builders'] += sklearn_bot.build_builders((
+    ('sklearn-py2.x-sid-sparc', sparc_slaves_sid),))
+c['builders'] += sklearn_bot.build_builders((
+    ('sklearn-py2.6-wheezy-sparc', sparc_slaves_wheezy),),
+    python='python2.6')
 """ Disabling these guys; they haven't worked for a while
 c['builders'].append(
     BuilderConfig(name="buildout-test2.6",


### PR DESCRIPTION
To get in effect buildslaves need to be started, for that buildmaster needs to reload its passwords file
