### PR TITLE
ENH: run nipy and dipy in both wheezy and sid chroots for sparc + RF

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -666,7 +666,9 @@ c['schedulers'] = [
                            'nibabel-py2.6-32',
                            'nibabel-py2.6-xp',
                            'nibabel-py2.7-win7',
-                           'nibabel-py2.6-sparc',
+                           'nibabel-py2.6-squeeze-sparc',
+                           'nibabel-py2.7-wheezy-sparc',
+                           'nibabel-py2.x-sid-sparc',
                            'nibabel-py2.7-ppc',
                            'nibabel-py2.6-arm',
                            'nibabel-py2.7-fedora',
@@ -696,7 +698,9 @@ c['schedulers'] = [
     nipy_bot.scheduler(['nipy-py2.6',
                         'nipy-py2.6-32',
                         'nipy-py2.6-xp',
-                        'nipy-py2.6-sparc',
+                        'nipy-py2.6-squeeze-sparc',
+                        'nipy-py2.7-wheezy-sparc',
+                        'nipy-py2.x-sid-sparc'
                         'nipy-py2.7-ppc',
                         'nipy-py2.6-arm',
                         'nipy-py2.7-fedora',
@@ -712,7 +716,9 @@ c['schedulers'] = [
     dipy_bot.scheduler(['dipy-py2.6',
                         'dipy-py2.6-32',
                         'dipy-py2.6-xp',
-                        'dipy-py2.6-sparc',
+                        'dipy-py2.6-squeeze-sparc',
+                        'dipy-py2.7-wheezy-sparc',
+                        'dipy-py2.x-sid-sparc',
                         'dipy-py2.6-arm',
                         'dipy-py2.7-fedora',
                         'dipy-py2.7-osx-10.6',
@@ -746,21 +752,21 @@ c['schedulers'] = [
                         'pandas-py2.x-sid-sparc',
                         'pandas-py3.x-sid-sparc',
                         'pandas-py2.6-wheezy-sparc',
-                        'pandas-py2.x-wheezy-sparc',
+                        'pandas-py2.7-wheezy-sparc',
                         'pandas-py3.x-wheezy-sparc',
                         ]),
     statsmodels_bot.scheduler([
                         'statsmodels-py2.x-sid-sparc',
                         # not yet
                         #'statsmodels-py3.x-sid-sparc',
-                        'statsmodels-py2.x-wheezy-sparc',
+                        'statsmodels-py2.7-wheezy-sparc',
                         #'statsmodels-py3.x-wheezy-sparc',
                         ]),
     pymvpa_bot.scheduler([
                         'pymvpa-py2.x-sid-sparc',
                         # not yet
                         #'pymvpa-py3.x-sid-sparc',
-                        'pymvpa-py2.x-wheezy-sparc',
+                        'pymvpa-py2.7-wheezy-sparc',
                         #'pymvpa-py3.x-wheezy-sparc',
                         'pymvpa-py2.7-osx-10.6',
                         'pymvpa-py2.7-osx-10.7',
@@ -773,7 +779,7 @@ c['schedulers'] = [
                         'fail2ban-py2.x-sid-sparc',
                         # whenever will add testing of 0.9
                         #'fail2ban-py3.x-sid-sparc',
-                        'fail2ban-py2.x-wheezy-sparc',
+                        'fail2ban-py2.7-wheezy-sparc',
                         #'fail2ban-py3.x-wheezy-sparc',
                         'fail2ban-py2.7-osx-10.6',
                         'fail2ban-py2.7-osx-10.8',
@@ -1296,7 +1302,9 @@ c['builders'] += nibabel_bot.build_builders(
      ('nibabel-py2.7-fedora', fedora_slaves),
      ('nibabel-py2.6-xp', xp_32_slaves),
      ('nibabel-py2.7-win7', win7_64_slaves),
-     ('nibabel-py2.6-sparc', sparc_slaves)))
+     ('nibabel-py2.6-squeeze-sparc', sparc_slaves),
+     ('nibabel-py2.7-wheezy-sparc', sparc_slaves_wheezy),
+     ('nibabel-py2.x-sid-sparc', sparc_slaves_sid)))
 # Python 3s into virtualenv
 c['builders'] += nibabel_bot.build_builders(
     (('nibabel-py3.2', linux_64_slaves),),
@@ -1340,7 +1348,9 @@ c['builders'] += nipy_bot.build_builders(
      ('nipy-py2.6-arm', arm_slaves),
      ('nipy-py2.7-fedora', fedora_slaves),
      ('nipy-py2.6-xp', xp_32_slaves),
-     ('nipy-py2.6-sparc', sparc_slaves)))
+     ('nipy-py2.6-squeeze-sparc', sparc_slaves),
+     ('nipy-py2.7-wheezy-sparc', sparc_slaves_wheezy),
+     ('nipy-py2.x-sid-sparc', sparc_slaves_sid)))
 # Python 3s into virtualenv
 c['builders'] += nipy_bot.build_builders(
     (('nipy-py3.2', linux_64_slaves),),
@@ -1367,7 +1377,9 @@ c['builders'] += dipy_bot.build_builders((
      ('dipy-py2.6-arm', arm_slaves),
      ('dipy-py2.7-fedora', fedora_slaves),
      ('dipy-py2.6-xp', xp_32_slaves),
-     ('dipy-py2.6-sparc', sparc_slaves)))
+     ('dipy-py2.6-squeeze-sparc', sparc_slaves),
+     ('dipy-py2.7-wheezy-sparc', sparc_slaves_wheezy),
+     ('dipy-py2.x-sid-sparc', sparc_slaves_sid)))
 # Python 3.2 into virtualenv
 c['builders'] += dipy_bot.build_builders(
     (('dipy-py3.2', linux_64_slaves),),
@@ -1398,7 +1410,8 @@ c['builders'] += regreg_bot.build_builders(
 # Pandas - can be tested only on recent debian releases
 c['builders'] += pandas_bot.build_builders(
     (('pandas-py2.x-sid-sparc', sparc_slaves_sid),
-     ('pandas-py2.x-wheezy-sparc', sparc_slaves_wheezy)))
+     ('pandas-py2.7-wheezy-sparc', sparc_slaves_wheezy)),
+    post_cmds=("python -c 'from pandas.util.print_versions import show_versions; show_versions()'",))
 # test on wheezy for python2.6
 c['builders'] += pandas_bot.build_builders(
     (('pandas-py2.6-wheezy-sparc', sparc_slaves_wheezy),),
@@ -1407,11 +1420,12 @@ c['builders'] += pandas_bot.build_builders(
 c['builders'] += pandas_bot.build_builders(
     (('pandas-py3.x-sid-sparc', sparc_slaves_sid),
      ('pandas-py3.x-wheezy-sparc', sparc_slaves_wheezy)),
+	post_cmds=("python3 -c 'from pandas.util.print_versions import show_versions; show_versions()'",),
     python='python3')
 # Statsmodels - can be tested only on recent debian releases
 c['builders'] += statsmodels_bot.build_builders(
     (('statsmodels-py2.x-sid-sparc', sparc_slaves_sid),
-     ('statsmodels-py2.x-wheezy-sparc', sparc_slaves_wheezy)),
+     ('statsmodels-py2.7-wheezy-sparc', sparc_slaves_wheezy)),
     post_cmds=("python -c 'from statsmodels.tools.print_version import show_versions; show_versions()'",))
 ## and python3 builders
 #c['builders'] += statsmodels_bot.build_builders(
@@ -1421,7 +1435,7 @@ c['builders'] += statsmodels_bot.build_builders(
 # PyMVPA
 c['builders'] += pymvpa_bot.build_builders(
     (('pymvpa-py2.x-sid-sparc', sparc_slaves_sid),
-     ('pymvpa-py2.x-wheezy-sparc', sparc_slaves_wheezy),
+     ('pymvpa-py2.7-wheezy-sparc', sparc_slaves_wheezy),
      ('pymvpa-py2.7-osx-10.6', osx_snowleopard_slaves),
      ('pymvpa-py2.7-osx-10.7', osx_lion_slaves),
      ('pymvpa-py2.7-osx-10.8', osx_mountainlion_slaves),
@@ -1452,7 +1466,7 @@ c['builders'].append(
 # Fail2ban
 c['builders'] += fail2ban_bot.build_builders(
     (('fail2ban-py2.x-sid-sparc', sparc_slaves_sid),
-     ('fail2ban-py2.x-wheezy-sparc', sparc_slaves_wheezy),
+     ('fail2ban-py2.7-wheezy-sparc', sparc_slaves_wheezy),
      ('fail2ban-py2.7-osx-10.6', osx_snowleopard_slaves),
      ('fail2ban-py2.7-osx-10.8', osx_mountainlion_slaves),
      ('fail2ban-py2.6-osx-10.5-ppc', osx_leopard_ppc_slaves),


### PR DESCRIPTION
NB There are uncommitted changes on the buildbot master box, so decided to go with the PR instead of direct push/pull/reconfig

RF: unified referencing of python on those releases where it is
already known for sure (thus 2.7-wheezy instead of non-informative
2.x-wheezy)

also added printout of versions for pandas (hope it works)
