### PR TITLE
Remove OS 10.5 builders for nitime, add python 3 builders.

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -798,9 +798,9 @@ c['schedulers'] = sum([
                           'nitime-py2.7-osx-10.6',
                           'nitime-py2.7-osx-10.7',
                           'nitime-py2.7-osx-10.8',
-                          'nitime-py2.6-osx-10.5-ppc',
-                          'nitime-py2.6-osx-10.5-intel',
-                         ]),
+                          'nitime-py3.2',
+                          'nitime-py3.3'
+                          ]),
     pyarbus_bot.schedulers(['pyarbus-py2.6',
                           ]),
     nipy_bot.schedulers(['nipy-py2.6',
@@ -1423,11 +1423,17 @@ c['builders'] += nitime_bot.build_builders(
      ('nitime-py2.7-osx-10.6', osx_snowleopard_slaves),
      ('nitime-py2.7-osx-10.7', osx_lion_slaves),
      ('nitime-py2.7-osx-10.8', osx_mountainlion_slaves),
-     ('nitime-py2.6-osx-10.5-ppc', osx_leopard_ppc_slaves),
-     ('nitime-py2.6-osx-10.5-intel', osx_leopard_intel_slaves),
      ('nitime-py2.6-arm', arm_slaves),
      ('nitime-py2.7-fedora', fedora_slaves),
-     ('nitime-py2.7-win32', win7_32_slaves)))
+     ('nitime-py2.7-win32', win7_32_slaves))
+    )
+c['builders'] += nitime_bot.build_builders(
+    (('nitime-py3.2', linux_64_slaves),),
+    python='python3.2')
+c['builders'] += nitime_bot.build_builders(
+    (('nitime-py3.3', osx_snowleopard_slaves),),
+    python='python3.3')
+
 # pyarbus
 c['builders'] += pyarbus_bot.build_builders(
     (('pyarbus-py2.6', linux_64_slaves),))


### PR DESCRIPTION
Is this the way to change the builders on the build-bots? Or do I need to do something more? 

Thanks! 
