### PR TITLE
Use insecure mode of ez_setup.

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -348,7 +348,7 @@ class GithubBot(object):
             'ez_setup.py']))
         if install_pip:
             factory.addStep(ShellCommand(
-                command=['python', 'ez_setup.py'],
+                command=['python', 'ez_setup.py', '--insecure'],
                 env=env))
         return env, workdir
 
@@ -1416,6 +1416,7 @@ c['builders'] += nibabel_bot.build_builders(
     (('nibabel-py2.7-pyd0.9.8', osx_mountainlion_slaves),),
     python='python2.7',
     pip_depends = ('nose', 'pydicom==0.9.8'))
+
 # Nitime
 c['builders'] += nitime_bot.build_builders(
     (('nitime-py2.6', linux_64_slaves),


### PR DESCRIPTION
See also:

https://bitbucket.org/pypa/setuptools/issue/106/ez_setuppy-fails-because-of-insecure-ssl
