### PR TITLE
RF: Testing dipy with no X requires using xvfbwrapper.

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -691,7 +691,8 @@ dipy_bot = GithubBot('nipy', 'dipy',
 # dipy bot for linux machines with optional pip_depends that
 # need an X window for testing
 dipy_bot_nox = GithubBot('nipy', 'dipy',
-    test_cmd = shlex.split('xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" nosetests --verbosity=3 --with-doctest dipy'),
+	test_env = dict(TEST_WITH_XVFB=True),
+    test_cmd = shlex.split('nosetests --verbosity=3 --with-doctest dipy'),
     pip_depends = ('nose', 'numpy>=1.7.1', 'cython>=0.18', 'nibabel'),
     build_timeout = 9600, # allow for longer registration builds
 )


### PR DESCRIPTION
This is triggered through a setting of an env variable.