### PR TITLE
Move some linux boxes to be `dipy_nox_bot`s

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -666,11 +666,11 @@ nibabel_bot = GithubBot('nipy', 'nibabel',
 )
 nitime_bot = GithubBot('nipy', 'nitime',
     test_cmd = nptest_command('nitime', verbose=None),
-    pip_depends = ('nose',)
+    pip_depends = ('nose', 'matplotlib')
 )
 pyarbus_bot = GithubBot('ivanov', 'pyarbus',
     test_cmd = nptest_command('pyarbus', verbose=None, use_agg=True),
-    pip_depends = ('nose','nitime')
+    pip_depends = ('nose', 'nitime')
 )
 nipy_bot = GithubBot('nipy', 'nipy',
     test_cmd = nptest_command('nipy', doctests=True),
@@ -836,7 +836,6 @@ c['schedulers'] = sum([
     nitime_bot.schedulers(['nitime-py2.6',
                           'nitime-py2.6-32',
                           'nitime-py2.7-win32',
-                          'nitime-py2.6-arm',
                           'nitime-py2.7-fedora',
                           'nitime-py2.7-osx-10.6',
                           'nitime-py2.7-osx-10.7',
@@ -1461,7 +1460,6 @@ c['builders'] += nitime_bot.build_builders(
      ('nitime-py2.7-osx-10.6', osx_snowleopard_slaves),
      ('nitime-py2.7-osx-10.7', osx_lion_slaves),
      ('nitime-py2.7-osx-10.10', osx_yosemite_slaves),
-     ('nitime-py2.6-arm', arm_slaves),
      ('nitime-py2.7-fedora', fedora_slaves),
      ('nitime-py2.7-win32', win7_32_slaves))
     )
@@ -1501,8 +1499,12 @@ c['builders'] += nipy_bot.build_builders(
 # http://bugs.python.org/issue8458
 c['builders'] += dipy_bot_nox.build_builders(
     (('dipy-py2.6', linux_64_slaves),
+     ('dipy-py2.7-wheezy-sparc', sparc_slaves_wheezy),
+     ('dipy-py2.x-sid-sparc', sparc_slaves_sid),
+     ('dipy-py2.6-squeeze-sparc', sparc_slaves),
      ('dipy-py2.6-32', linux_32_slaves),
-))
+     ))
+
 c['builders'] += dipy_bot.build_builders((
      ('dipy-py2.7-osx-10.6', osx_snowleopard_slaves),
      ('dipy-py2.7-osx-10.7', osx_lion_slaves),
@@ -1510,9 +1512,8 @@ c['builders'] += dipy_bot.build_builders((
      ('dipy-py2.7-debian-ppc', debian_ppc_slaves),
      ('dipy-py2.7-fedora', fedora_slaves),
      ('dipy-py2.7-win32', win7_32_slaves),
-     ('dipy-py2.6-squeeze-sparc', sparc_slaves),
-     ('dipy-py2.7-wheezy-sparc', sparc_slaves_wheezy),
-     ('dipy-py2.x-sid-sparc', sparc_slaves_sid)))
+     ))
+
 # Python 3.2 into virtualenv
 c['builders'] += dipy_bot.build_builders(
     (('dipy-py3.4', linux_64_slaves),),


### PR DESCRIPTION
Also: handle nitime matplotlib dependency in nitime bots
And: retire the nitime ARM bot.

I am getting a connection refused from the bot machine at the moment, so trying to apply the changes from here. 